### PR TITLE
Add serializable NullValue type

### DIFF
--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
@@ -58,6 +58,11 @@ public class ResultDeserializer extends StdDeserializer<Result<?, ?>> {
       JavaType type
   ) throws IOException {
     JsonNode valueNode = node.has(fieldName) ? node.findValue(fieldName) : node;
-    return objectMapper.readerFor(type).readValue(valueNode);
+    if (type.getRawClass() == NullValue.class && valueNode.isNull()) {
+      // Our version of Jackson doesn't allow custom deserialization of null
+      return NullValue.get();
+    } else {
+      return objectMapper.readerFor(type).readValue(valueNode);
+    }
   }
 }

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -74,6 +74,11 @@ public class ResultModuleTest {
       ImmutableTable.<String, String, String> builder().put("row", "column", "value").build());
   private static final String TABLE_ERR_JSON = "{\"row\":{\"column\":\"value\"},\"@result\":\"ERR\"}";
 
+  private static final Result<NullValue, String> NULL_OK = Result.nullOk();
+  private static final String NULL_OK_JSON = "{\"@ok\":\"NULL_VALUE\",\"@result\":\"OK\"}";
+  private static final Result<String, NullValue> NULL_ERR = Result.nullErr();
+  private static final String NULL_ERR_JSON = "{\"@error\":\"NULL_VALUE\",\"@result\":\"ERR\"}";
+
   private static ObjectMapper objectMapper;
 
   @BeforeClass
@@ -159,6 +164,16 @@ public class ResultModuleTest {
   @Test
   public void itSerializesTableErr() throws Exception {
     itSerializes(TABLE_ERR, TABLE_ERR_JSON);
+  }
+
+  @Test
+  public void itSerializesNullOk() throws Exception {
+    itSerializes(NULL_OK, NULL_OK_JSON);
+  }
+
+  @Test
+  public void itSerializesNullErr() throws Exception {
+    itSerializes(NULL_ERR, NULL_ERR_JSON);
   }
 
   @Test
@@ -306,6 +321,24 @@ public class ResultModuleTest {
         TABLE_ERR
     )).isInstanceOf(JsonMappingException.class)
       .hasMessageStartingWith("Can not construct instance of com.google.common.collect.Table");
+  }
+
+  @Test
+  public void itDeserializesNullOk() throws Exception {
+    itDeserializes(
+        NULL_OK_JSON,
+        new TypeReference<Result<NullValue, String>>(){},
+        NULL_OK
+    );
+  }
+
+  @Test
+  public void itDeserializesNullErr() throws Exception {
+    itDeserializes(
+        NULL_ERR_JSON,
+        new TypeReference<Result<String, NullValue>>(){},
+        NULL_ERR
+    );
   }
 
   private void itSerializes(Result<?, ?> result, String expectedJson) throws JsonProcessingException {

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -75,9 +75,9 @@ public class ResultModuleTest {
   private static final String TABLE_ERR_JSON = "{\"row\":{\"column\":\"value\"},\"@result\":\"ERR\"}";
 
   private static final Result<NullValue, String> NULL_OK = Result.nullOk();
-  private static final String NULL_OK_JSON = "{\"@ok\":\"NULL_VALUE\",\"@result\":\"OK\"}";
+  private static final String NULL_OK_JSON = "{\"@ok\":null,\"@result\":\"OK\"}";
   private static final Result<String, NullValue> NULL_ERR = Result.nullErr();
-  private static final String NULL_ERR_JSON = "{\"@error\":\"NULL_VALUE\",\"@result\":\"ERR\"}";
+  private static final String NULL_ERR_JSON = "{\"@error\":null,\"@result\":\"ERR\"}";
 
   private static ObjectMapper objectMapper;
 
@@ -350,7 +350,7 @@ public class ResultModuleTest {
       TypeReference<Result<OK, ERR>> type,
       Result<OK, ERR> expected
   ) throws IOException {
-    Result<List<String>, List<String>> actual = objectMapper.readValue(inputJson, type);
+    Result<OK, ERR> actual = objectMapper.readValue(inputJson, type);
     assertThat(actual).isEqualTo(expected);
   }
 

--- a/algebra/src/main/java/com/hubspot/algebra/NullValue.java
+++ b/algebra/src/main/java/com/hubspot/algebra/NullValue.java
@@ -1,14 +1,20 @@
 package com.hubspot.algebra;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum NullValue {
-  // We name it this instead of INSTANCE for more human-readable JSON
   /**
    * @deprecated Call {@link NullValue#get()} instead of accessing this enum constant directly.
    */
   @Deprecated
-  NULL_VALUE;
+  INSTANCE;
 
   public static NullValue get() {
-    return NULL_VALUE;
+    return INSTANCE;
+  }
+
+  @JsonValue
+  Object getJsonValue() {
+    return null;
   }
 }

--- a/algebra/src/main/java/com/hubspot/algebra/NullValue.java
+++ b/algebra/src/main/java/com/hubspot/algebra/NullValue.java
@@ -2,6 +2,10 @@ package com.hubspot.algebra;
 
 public enum NullValue {
   // We name it this instead of INSTANCE for more human-readable JSON
+  /**
+   * @deprecated Call {@link NullValue#get()} instead of accessing this enum constant directly.
+   */
+  @Deprecated
   NULL_VALUE;
 
   public static NullValue get() {

--- a/algebra/src/main/java/com/hubspot/algebra/NullValue.java
+++ b/algebra/src/main/java/com/hubspot/algebra/NullValue.java
@@ -1,0 +1,10 @@
+package com.hubspot.algebra;
+
+public enum NullValue {
+  // We name it this instead of INSTANCE for more human-readable JSON
+  NULL_VALUE;
+
+  public static NullValue get() {
+    return NULL_VALUE;
+  }
+}

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -18,6 +18,14 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return Results.err(error);
   }
 
+  public static <ERROR_TYPE> Result<NullValue, ERROR_TYPE> nullOk() {
+    return Results.ok(NullValue.get());
+  }
+
+  public static <SUCCESS_TYPE> Result<SUCCESS_TYPE, NullValue> nullErr() {
+    return Results.err(NullValue.get());
+  }
+
   Result() {}
 
   public boolean isOk() {

--- a/algebra/src/main/java/com/hubspot/algebra/VoidResult.java
+++ b/algebra/src/main/java/com/hubspot/algebra/VoidResult.java
@@ -7,6 +7,10 @@ import org.derive4j.Data;
 import org.derive4j.Derive;
 import org.derive4j.Visibility;
 
+/**
+ * @deprecated use {@link Result#nullOk()} instead.
+ */
+@Deprecated
 @Data(@Derive(withVisibility = Visibility.Package))
 public abstract class VoidResult<ERROR_TYPE> extends Result<Void, ERROR_TYPE>{
 


### PR DESCRIPTION
The `VoidResult` type is not serializable (it NPEs on read). This adds the sentinel `NullValue` enum singleton in order to properly represent and serialized results with no value.

Some question marks are:
- Is `okNull` a better method name than `nullOk`?
- Should we serialize `NullValue.NULL_VALUE` as `null`?

@zklapow @szabowexler @jhaber @kmclarnon 