### PR TITLE
Use basepom 25.2 and clean things up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,12 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>18.2</version>
+    <version>25.2</version>
   </parent>
 
   <artifactId>algebra-parent</artifactId>
   <version>1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <properties>
-    <project.build.targetJdk>1.8</project.build.targetJdk>
-    <dep.derive4j.version>0.12.3</dep.derive4j.version>
-    <dep.immutables-utils.version>1.2</dep.immutables-utils.version>
-  </properties>
 
   <modules>
     <module>algebra</module>
@@ -24,27 +18,26 @@
     <module>algebra-jackson</module>
   </modules>
 
+  <properties>
+    <dep.derive4j.version>0.12.3</dep.derive4j.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>hubspot-style</artifactId>
-        <version>${dep.immutables-utils.version}</version>
+        <version>${dep.hubspot-immutables.version}</version>
       </dependency>
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>immutables-exceptions</artifactId>
-        <version>${dep.immutables-utils.version}</version>
+        <version>${dep.hubspot-immutables.version}</version>
       </dependency>
       <dependency>
         <groupId>com.hubspot</groupId>
         <artifactId>algebra</artifactId>
-        <version>1.3-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.immutables</groupId>
-        <artifactId>value</artifactId>
-        <version>2.2.10</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.derive4j</groupId>
@@ -55,16 +48,6 @@
         <groupId>org.derive4j</groupId>
         <artifactId>derive4j-annotation</artifactId>
         <version>${dep.derive4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.7.9</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.7.9.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Use basepom 25.2 and fix things up. With any luck this will remove some of those jackson warnings we're seeing, though I'm not too optimistic. This at least puts this on a secure version.

@jhaber @kmclarnon @jonathanwgoodwin 