### PR TITLE
Upgrade derive4j to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <dep.derive4j.version>0.12.3</dep.derive4j.version>
+    <dep.derive4j.version>1.1.0</dep.derive4j.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This builds and the generated code contains no references to derive4j, so this should be safe.

This will allow us to compile this code with jdk 11.

@szabowexler @jhaber @kmclarnon @zklapow 