### PR TITLE
Add support for flatMapErr

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -63,6 +63,17 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return nestedResult.unwrapOrElseThrow();
   }
 
+  public <NEW_ERROR_TYPE> Result<SUCCESS_TYPE, NEW_ERROR_TYPE> flatMapErr(Function<ERROR_TYPE, Result<SUCCESS_TYPE, NEW_ERROR_TYPE>> mapper) {
+    Result<SUCCESS_TYPE, Result<SUCCESS_TYPE, NEW_ERROR_TYPE>> nestedResult = Results.<SUCCESS_TYPE, ERROR_TYPE, Result<SUCCESS_TYPE, NEW_ERROR_TYPE>>modErr(mapper)
+        .apply(this);
+
+    if (nestedResult.isOk()) {
+      return ok(nestedResult.unwrapOrElseThrow());
+    }
+
+    return nestedResult.unwrapErrOrElseThrow();
+  }
+
   public <X extends Throwable> SUCCESS_TYPE unwrapOrElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
     return Results.getOk(this)
         .orElseThrow(exceptionSupplier);

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.junit.Test;
 
@@ -56,6 +57,20 @@ public class ResultTest {
 
     Result<String, String> mappedOk = OK_RESULT.mapErr(SampleError::name);
     assertThat(mappedOk.unwrapOrElseThrow()).isEqualTo(OK_RESULT.unwrapOrElseThrow());
+  }
+
+
+  @Test
+  public void itFlatMapsErr() throws Exception {
+    Function<SampleError, Result<String, String>> errMapper = (SampleError err) -> Result.err(err.name());
+    Result<String, String> mappedErr = ERR_RESULT.flatMapErr(errMapper);
+    assertThat(mappedErr.unwrapErrOrElseThrow()).isEqualTo(SampleError.TEST_ERROR.name());
+
+    Result<String, String> mappedOk = OK_RESULT.flatMapErr(errMapper);
+    assertThat(mappedOk.unwrapOrElseThrow()).isEqualTo(OK_RESULT.unwrapOrElseThrow());
+
+    mappedErr = ERR_RESULT.flatMapErr(err -> Result.ok("ok!"));
+    assertThat(mappedErr.unwrapOrElseThrow()).isEqualTo("ok!");
   }
 
   @Test


### PR DESCRIPTION
Useful for handling errors when there is a known fallback for some or all failure cases. Languages like Swift (`flatMapErr`) and Rust (`or_else`) support this in their `Result` types.

Ex:
```
result = some_operation();
result.flatMapErr(err -> 
  switch (err) {
    case SOFT_ERROR:
      return result_of_fallback_operation();
   case HARD_ERROR:
      return Result.err(err);
  }
```

Replaces #26 