### PR TITLE
Fix issue with deserializing nested `Result`s from JSON

### DIFF
--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
@@ -32,7 +32,7 @@ public class ResultDeserializer extends StdDeserializer<Result<?, ?>> {
                                   DeserializationContext ctxt) throws IOException {
     ObjectCodec codec = p.getCodec();
     ObjectNode node = codec.readTree(p);
-    JsonNode caseNode = node.findValue(CASE_FIELD_NAME);
+    JsonNode caseNode = node.get(CASE_FIELD_NAME);
 
     if (caseNode == null) {
       throw new JsonMappingException(p, String.format("Could not deserialize input as a Result. The required %s field is missing.", CASE_FIELD_NAME));
@@ -56,7 +56,7 @@ public class ResultDeserializer extends StdDeserializer<Result<?, ?>> {
       String fieldName,
       JavaType type
   ) throws IOException {
-    JsonNode valueNode = node.has(fieldName) ? node.findValue(fieldName) : node;
+    JsonNode valueNode = node.has(fieldName) ? node.get(fieldName) : node;
     if (type.getRawClass() == NullValue.class && valueNode.isNull()) {
       // Our version of Jackson doesn't allow custom deserialization of null
       return NullValue.get();

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -79,6 +79,22 @@ public class ResultModuleTest {
   private static final Result<String, NullValue> NULL_ERR = Result.nullErr();
   private static final String NULL_ERR_JSON = "{\"@error\":null,\"@result\":\"ERR\"}";
 
+  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_OK_OK =
+      Result.ok(Collections.singletonMap("key", Result.ok(new TestBean("test"))));
+  private static final String NESTED_OK_OK_JSON = "{\"key\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"OK\"}";
+
+  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_OK_ERR =
+      Result.ok(Collections.singletonMap("key", Result.err(TestError.ERROR)));
+  private static final String NESTED_OK_ERR_JSON = "{\"key\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"OK\"}";
+
+  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_ERR_OK =
+      Result.err(Collections.singletonMap("key", Result.ok(new TestBean("test"))));
+  private static final String NESTED_ERR_OK_JSON = "{\"key\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"ERR\"}";
+
+  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_ERR_ERR =
+      Result.err(Collections.singletonMap("key", Result.err(TestError.ERROR)));
+  private static final String NESTED_ERR_ERR_JSON = "{\"key\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"ERR\"}";
+
   private static ObjectMapper objectMapper;
 
   @BeforeClass
@@ -338,6 +354,42 @@ public class ResultModuleTest {
         NULL_ERR_JSON,
         new TypeReference<Result<String, NullValue>>(){},
         NULL_ERR
+    );
+  }
+
+  @Test
+  public void itDeserializesNestedOkOk() throws Exception {
+    itDeserializes(
+        NESTED_OK_OK_JSON,
+        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        NESTED_OK_OK
+    );
+  }
+
+  @Test
+  public void itDeserializesNestedOkErr() throws Exception {
+    itDeserializes(
+        NESTED_OK_ERR_JSON,
+        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        NESTED_OK_ERR
+    );
+  }
+
+  @Test
+  public void itDeserializesNestedErrOk() throws Exception {
+    itDeserializes(
+        NESTED_ERR_OK_JSON,
+        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        NESTED_ERR_OK
+    );
+  }
+
+  @Test
+  public void itDeserializesNestedErrErr() throws Exception {
+    itDeserializes(
+        NESTED_ERR_ERR_JSON,
+        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        NESTED_ERR_ERR
     );
   }
 

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -193,6 +193,26 @@ public class ResultModuleTest {
   }
 
   @Test
+  public void itSerializesNestedOkOk() throws Exception {
+    itSerializes(NESTED_OK_OK, NESTED_OK_OK_JSON);
+  }
+
+  @Test
+  public void itSerializesNestedOkErr() throws Exception {
+    itSerializes(NESTED_OK_ERR, NESTED_OK_ERR_JSON);
+  }
+
+  @Test
+  public void itSerializesNestedErrOk() throws Exception {
+    itSerializes(NESTED_ERR_OK, NESTED_ERR_OK_JSON);
+  }
+
+  @Test
+  public void itSerializesNestedErrErr() throws Exception {
+    itSerializes(NESTED_ERR_ERR, NESTED_ERR_ERR_JSON);
+  }
+
+  @Test
   public void itDeserializesBeanOk() throws Exception {
     itDeserializes(
         BEAN_OK_JSON,

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -79,21 +79,21 @@ public class ResultModuleTest {
   private static final Result<String, NullValue> NULL_ERR = Result.nullErr();
   private static final String NULL_ERR_JSON = "{\"@error\":null,\"@result\":\"ERR\"}";
 
-  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_OK_OK =
-      Result.ok(Collections.singletonMap("key", Result.ok(new TestBean("test"))));
-  private static final String NESTED_OK_OK_JSON = "{\"key\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"OK\"}";
+  private static final Result<Result<TestBean, TestError>, Result<TestBean, TestError>> NESTED_OK_OK =
+      Result.ok(Result.ok(new TestBean("test")));
+  private static final String NESTED_OK_OK_JSON = "{\"@ok\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"OK\"}";
 
-  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_OK_ERR =
-      Result.ok(Collections.singletonMap("key", Result.err(TestError.ERROR)));
-  private static final String NESTED_OK_ERR_JSON = "{\"key\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"OK\"}";
+  private static final Result<Result<TestBean, TestError>, Result<TestBean, TestError>> NESTED_OK_ERR =
+      Result.ok(Result.err(TestError.ERROR));
+  private static final String NESTED_OK_ERR_JSON = "{\"@ok\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"OK\"}";
 
-  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_ERR_OK =
-      Result.err(Collections.singletonMap("key", Result.ok(new TestBean("test"))));
-  private static final String NESTED_ERR_OK_JSON = "{\"key\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"ERR\"}";
+  private static final Result<Result<TestBean, TestError>, Result<TestBean, TestError>> NESTED_ERR_OK =
+      Result.err(Result.ok(new TestBean("test")));
+  private static final String NESTED_ERR_OK_JSON = "{\"@error\":{\"value\":\"test\",\"@result\":\"OK\"},\"@result\":\"ERR\"}";
 
-  private static final Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>> NESTED_ERR_ERR =
-      Result.err(Collections.singletonMap("key", Result.err(TestError.ERROR)));
-  private static final String NESTED_ERR_ERR_JSON = "{\"key\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"ERR\"}";
+  private static final Result<Result<TestBean, TestError>, Result<TestBean, TestError>> NESTED_ERR_ERR =
+      Result.err(Result.err(TestError.ERROR));
+  private static final String NESTED_ERR_ERR_JSON = "{\"@error\":{\"name\":\"ERROR\",\"@result\":\"ERR\"},\"@result\":\"ERR\"}";
 
   private static ObjectMapper objectMapper;
 
@@ -381,7 +381,7 @@ public class ResultModuleTest {
   public void itDeserializesNestedOkOk() throws Exception {
     itDeserializes(
         NESTED_OK_OK_JSON,
-        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        new TypeReference<Result<Result<TestBean, TestError>, Result<TestBean, TestError>>>(){},
         NESTED_OK_OK
     );
   }
@@ -390,7 +390,7 @@ public class ResultModuleTest {
   public void itDeserializesNestedOkErr() throws Exception {
     itDeserializes(
         NESTED_OK_ERR_JSON,
-        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        new TypeReference<Result<Result<TestBean, TestError>, Result<TestBean, TestError>>>(){},
         NESTED_OK_ERR
     );
   }
@@ -399,7 +399,7 @@ public class ResultModuleTest {
   public void itDeserializesNestedErrOk() throws Exception {
     itDeserializes(
         NESTED_ERR_OK_JSON,
-        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        new TypeReference<Result<Result<TestBean, TestError>, Result<TestBean, TestError>>>(){},
         NESTED_ERR_OK
     );
   }
@@ -408,7 +408,7 @@ public class ResultModuleTest {
   public void itDeserializesNestedErrErr() throws Exception {
     itDeserializes(
         NESTED_ERR_ERR_JSON,
-        new TypeReference<Result<Map<String, Result<TestBean, TestError>>, Map<String, Result<TestBean, TestError>>>>(){},
+        new TypeReference<Result<Result<TestBean, TestError>, Result<TestBean, TestError>>>(){},
         NESTED_ERR_ERR
     );
   }


### PR DESCRIPTION
If a JSON body had a type structure with nested `Result`s, we would sometimes fail to parse it. This was because the deserializer looked for the first `@result` field it found, but it did this using Jackson's `findValue()`, which essentially does a depth-first search through the JSON and would sometimes find the `@result` of an inner nested result rather than the outer result.

For example:
```js
{
  "outerField": {
    "innerObject": {
      "innerField": "value",
      "@result": "ERR"
    }
  },
  "@result": "OK"
}
```

When parsing the outer `Result`, the deserializer would find the inner `"@result": "ERR"` rather than the outer `"@result": "OK"`.

This PR fixes that by using Jackson's `get()` instead of `findValue()`, which should only find immediate children of the JSON node (without recursively searching down the tree).

I haven't been able to think of a case where something would be depending on the previous `findValue()` behavior, but I guess it's possible. If someone thinks there could be cases that this change would break, I could update it to do a `firstNonNull(get(...), findValue(...))` to try to maintain better backwards compatibility.

/cc @stevegutz @jhaber @szabowexler 