### PR TITLE
Add ifOkOrElseError

### DIFF
--- a/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
+++ b/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
@@ -1,11 +1,12 @@
 package com.hubspot.assertj.algebra.api;
 
-import com.hubspot.algebra.Result;
+import static com.hubspot.assertj.algebra.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 
-import static com.hubspot.assertj.algebra.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import com.hubspot.algebra.Result;
 
 public class ResultAssertTest {
   private void assertThatAssertionErrorIsThrown(ThrowingCallable throwingCallable, String expectedMessage, Object... messageParameters) {

--- a/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
+++ b/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
@@ -4,11 +4,7 @@ import com.hubspot.algebra.Result;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static com.hubspot.assertj.algebra.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ResultAssertTest {
@@ -46,26 +42,6 @@ public class ResultAssertTest {
   @Test
   public void itPassesWhenExtractingErrValueOnErr() throws Exception {
     assertThat(Result.err(1)).extractingErr().isEqualTo(1);
-  }
-
-  @Test
-  public void itPassesWhenConsumingOkOnIfOkOrElseErr() throws Exception {
-    List<String> okResults = new ArrayList<>();
-    List<String> errorResults = new ArrayList<>();
-    Result<String, String> okResult = Result.ok("test");
-    okResult.ifOkOrElseError(okResults::add, errorResults::add);
-    assertThat(okResults).contains(okResult.unwrapOrElseThrow());
-    assertThat(errorResults).isEmpty();
-  }
-
-  @Test
-  public void itPassesWhenConsumingErrorOnIfOkOrElseErr() throws Exception {
-    List<String> okResults = new ArrayList<>();
-    List<String> errorResults = new ArrayList<>();
-    Result<String, String> errorResult = Result.err("test");
-    errorResult.ifOkOrElseError(okResults::add, errorResults::add);
-    assertThat(okResults).isEmpty();
-    assertThat(errorResults).contains(errorResult.unwrapErrOrElseThrow());
   }
 
   @Test

--- a/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
+++ b/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
@@ -1,12 +1,15 @@
 package com.hubspot.assertj.algebra.api;
 
-import static com.hubspot.assertj.algebra.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
+import com.hubspot.algebra.Result;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.Test;
 
-import com.hubspot.algebra.Result;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hubspot.assertj.algebra.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ResultAssertTest {
   private void assertThatAssertionErrorIsThrown(ThrowingCallable throwingCallable, String expectedMessage, Object... messageParameters) {
@@ -43,6 +46,26 @@ public class ResultAssertTest {
   @Test
   public void itPassesWhenExtractingErrValueOnErr() throws Exception {
     assertThat(Result.err(1)).extractingErr().isEqualTo(1);
+  }
+
+  @Test
+  public void itPassesWhenConsumingOkOnIfOkOrElseErr() throws Exception {
+    List<String> okResults = new ArrayList<>();
+    List<String> errorResults = new ArrayList<>();
+    Result<String, String> okResult = Result.ok("test");
+    okResult.ifOkOrElseError(okResults::add, errorResults::add);
+    assertThat(okResults).contains(okResult.unwrapOrElseThrow());
+    assertThat(errorResults).isEmpty();
+  }
+
+  @Test
+  public void itPassesWhenConsumingErrorOnIfOkOrElseErr() throws Exception {
+    List<String> okResults = new ArrayList<>();
+    List<String> errorResults = new ArrayList<>();
+    Result<String, String> errorResult = Result.err("test");
+    errorResult.ifOkOrElseError(okResults::add, errorResults::add);
+    assertThat(okResults).isEmpty();
+    assertThat(errorResults).contains(errorResult.unwrapErrOrElseThrow());
   }
 
   @Test

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -44,6 +44,11 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     Results.getErr(this).ifPresent(consumer);
   }
 
+  public void ifOkOrElseError(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
+    Results.getOk(this).ifPresent(okConsumer);
+    Results.getErr(this).ifPresent(errConsumer);
+  }
+
   public <NEW_ERROR_TYPE> Result<SUCCESS_TYPE, NEW_ERROR_TYPE> mapErr(Function<ERROR_TYPE, NEW_ERROR_TYPE> mapper) {
     return Results.<SUCCESS_TYPE, ERROR_TYPE, NEW_ERROR_TYPE>modErr(mapper).apply(this);
   }

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -44,7 +44,7 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     Results.getErr(this).ifPresent(consumer);
   }
 
-  public void ifOkOrElseError(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
+  public void ifOkOrErr(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
     Results.getOk(this).ifPresent(okConsumer);
     Results.getErr(this).ifPresent(errConsumer);
   }

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -45,8 +45,8 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
   }
 
   public void consume(Consumer<? super ERROR_TYPE> errConsumer, Consumer<? super SUCCESS_TYPE> okConsumer) {
-    Results.getOk(this).ifPresent(okConsumer);
-    Results.getErr(this).ifPresent(errConsumer);
+    ifOk(okConsumer);
+    ifErr(errConsumer);
   }
 
   public <NEW_ERROR_TYPE> Result<SUCCESS_TYPE, NEW_ERROR_TYPE> mapErr(Function<ERROR_TYPE, NEW_ERROR_TYPE> mapper) {

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -44,7 +44,7 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     Results.getErr(this).ifPresent(consumer);
   }
 
-  public void consume(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
+  public void consume(Consumer<? super ERROR_TYPE> errConsumer, Consumer<? super SUCCESS_TYPE> okConsumer) {
     Results.getOk(this).ifPresent(okConsumer);
     Results.getErr(this).ifPresent(errConsumer);
   }

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -44,7 +44,7 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     Results.getErr(this).ifPresent(consumer);
   }
 
-  public void ifOkOrErr(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
+  public void consume(Consumer<? super SUCCESS_TYPE> okConsumer, Consumer<? super ERROR_TYPE> errConsumer) {
     Results.getOk(this).ifPresent(okConsumer);
     Results.getErr(this).ifPresent(errConsumer);
   }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -1,5 +1,8 @@
 package com.hubspot.algebra;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
@@ -8,9 +11,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ResultTest {
   private static final String SAMPLE_STRING = "Hello";

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -1,16 +1,16 @@
 package com.hubspot.algebra;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.junit.Test;
-
-import com.google.common.collect.ImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class ResultTest {
   private static final String SAMPLE_STRING = "Hello";
@@ -171,5 +171,23 @@ public class ResultTest {
     Result<Integer, ImmutableList<String>> result = Result.err(ImmutableList.of(SAMPLE_STRING));
     result.ifErr(consumer);
     assertThat(!check.isEmpty());
+  }
+
+  @Test
+  public void itPassesWhenConsumingOkOnIfOkOrErr() throws Exception {
+    List<String> okResults = new ArrayList<>();
+    List<SampleError> errorResults = Collections.emptyList();
+    OK_RESULT.ifOkOrErr(okResults::add, errorResults::add);
+    assertThat(okResults).contains(OK_RESULT.unwrapOrElseThrow());
+    assertThat(errorResults).isEmpty();
+  }
+
+  @Test
+  public void itPassesWhenConsumingErrorOnIfOkOrErr() throws Exception {
+    List<String> okResults = Collections.emptyList();
+    List<SampleError> errorResults = new ArrayList<>();
+    ERR_RESULT.ifOkOrErr(okResults::add, errorResults::add);
+    assertThat(okResults).isEmpty();
+    assertThat(errorResults).contains(ERR_RESULT.unwrapErrOrElseThrow());
   }
 }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -174,19 +174,19 @@ public class ResultTest {
   }
 
   @Test
-  public void itPassesWhenConsumingOkOnIfOkOrErr() throws Exception {
+  public void itConsumesOks() throws Exception {
     List<String> okResults = new ArrayList<>();
     List<SampleError> errorResults = Collections.emptyList();
-    OK_RESULT.ifOkOrErr(okResults::add, errorResults::add);
+    OK_RESULT.consume(okResults::add, errorResults::add);
     assertThat(okResults).contains(OK_RESULT.unwrapOrElseThrow());
     assertThat(errorResults).isEmpty();
   }
 
   @Test
-  public void itPassesWhenConsumingErrorOnIfOkOrErr() throws Exception {
+  public void itConsumesErrors() throws Exception {
     List<String> okResults = Collections.emptyList();
     List<SampleError> errorResults = new ArrayList<>();
-    ERR_RESULT.ifOkOrErr(okResults::add, errorResults::add);
+    ERR_RESULT.consume(okResults::add, errorResults::add);
     assertThat(okResults).isEmpty();
     assertThat(errorResults).contains(ERR_RESULT.unwrapErrOrElseThrow());
   }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -3,14 +3,15 @@ package com.hubspot.algebra;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import com.google.common.collect.ImmutableList;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 public class ResultTest {
   private static final String SAMPLE_STRING = "Hello";

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -177,7 +177,7 @@ public class ResultTest {
   public void itConsumesOks() throws Exception {
     List<String> okResults = new ArrayList<>();
     List<SampleError> errorResults = Collections.emptyList();
-    OK_RESULT.consume(okResults::add, errorResults::add);
+    OK_RESULT.consume(errorResults::add, okResults::add);
     assertThat(okResults).contains(OK_RESULT.unwrapOrElseThrow());
     assertThat(errorResults).isEmpty();
   }
@@ -186,7 +186,7 @@ public class ResultTest {
   public void itConsumesErrors() throws Exception {
     List<String> okResults = Collections.emptyList();
     List<SampleError> errorResults = new ArrayList<>();
-    ERR_RESULT.consume(okResults::add, errorResults::add);
+    ERR_RESULT.consume(errorResults::add, okResults::add);
     assertThat(okResults).isEmpty();
     assertThat(errorResults).contains(ERR_RESULT.unwrapErrOrElseThrow());
   }


### PR DESCRIPTION
Added `Result::consume` to avoid scenarios that look like:

```java
result.match(
  err -> {
    errorConsumer(err);
    return null;
  },
  ok -> {
    okConsumer(ok);
    return null;
  });
  ```
  
  for this:
  ```java
result.consume(
    this::errConsumer,
    this::okConsumer
);
  ```

Happy to rename or rearrange the new method. The standard library Optional interface uses `ifPresentOrElse` but `Result::match` expects the `err` handling first, `ok` handling second
  
