### PR TITLE
Enable IntelliJ <Click to see difference> feature when result comparison fails

### DIFF
--- a/algebra-testing/src/main/java/com/hubspot/assertj/algebra/api/ResultAssert.java
+++ b/algebra-testing/src/main/java/com/hubspot/assertj/algebra/api/ResultAssert.java
@@ -47,7 +47,7 @@ public class ResultAssert<T, E> extends AbstractAssert<ResultAssert<T, E>, Resul
   public ResultAssert<T, E> containsErr(Object value) {
     Objects.instance().assertNotNull(info, actual);
     if (!actual.isErr() || !actual.unwrapErrOrElseThrow().equals(value)) {
-      throw failures.failure(info, ResultShouldBeErrWithValue.shouldBeOkWithValue(actual, value));
+      throw failures.failure(info, ResultShouldBeErrWithValue.shouldBeErrWithValue(actual, value));
     }
     return this;
   }

--- a/algebra-testing/src/main/java/com/hubspot/assertj/algebra/error/ResultShouldBeErrWithValue.java
+++ b/algebra-testing/src/main/java/com/hubspot/assertj/algebra/error/ResultShouldBeErrWithValue.java
@@ -10,11 +10,13 @@ public class ResultShouldBeErrWithValue extends BasicErrorMessageFactory {
     super(format, arguments);
   }
 
-  public static <T, E> ErrorMessageFactory shouldBeOkWithValue(Result<T, E> actual, Object value) {
+  public static <T, E> ErrorMessageFactory shouldBeErrWithValue(Result<T, E> actual, Object error) {
     if (actual.isErr()) {
-      return new ResultShouldBeErrWithValue("Expecting Result to be Err containing <%s> but contained <%s>", value, actual.unwrapErrOrElseThrow());
+      E actualError = actual.unwrapErrOrElseThrow();
+      return new ResultShouldBeErrWithValue("Expecting Result to be Err containing <%s> but contained <%s>. expected:<%s> but was:<%s>", error, actualError, error, actualError);
     } else {
-      return new ResultShouldBeErrWithValue("Expecting Result to be Err containing <%s> but was Ok containing <%s>", value, actual.unwrapOrElseThrow());
+      return new ResultShouldBeErrWithValue("Expecting Result to be Err containing <%s> but was Ok containing <%s>", error, actual.unwrapOrElseThrow());
     }
   }
 }
+

--- a/algebra-testing/src/main/java/com/hubspot/assertj/algebra/error/ResultShouldBeOkWithValue.java
+++ b/algebra-testing/src/main/java/com/hubspot/assertj/algebra/error/ResultShouldBeOkWithValue.java
@@ -12,7 +12,8 @@ public class ResultShouldBeOkWithValue extends BasicErrorMessageFactory {
 
   public static <T, E> ErrorMessageFactory shouldBeOkWithValue(Result<T, E> actual, Object value) {
     if (actual.isOk()) {
-      return new ResultShouldBeOkWithValue("Expecting Result to be Ok containing <%s> but contained <%s>", value, actual.unwrapOrElseThrow());
+      T actualValue = actual.unwrapOrElseThrow();
+      return new ResultShouldBeOkWithValue("Expecting Result to be Ok containing <%s> but contained <%s>. expected:<%s> but was:<%s>", value, actualValue, value, actualValue);
     } else {
       return new ResultShouldBeOkWithValue("Expecting Result to be Ok containing <%s> but was Err containing <%s>", value, actual.unwrapErrOrElseThrow());
     }

--- a/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
+++ b/algebra-testing/src/test/java/com/hubspot/assertj/algebra/api/ResultAssertTest.java
@@ -61,16 +61,20 @@ public class ResultAssertTest {
 
   @Test
   public void itFailsWhenAssertingOkValueOnOkWithDifferentValue() throws Exception {
+    String expected = "Ok";
+    String actual = "Bad";
     assertThatAssertionErrorIsThrown(() -> assertThat(Result.ok("Bad")).containsOk("Ok"),
-                                     "Expecting Result to be Ok containing <\"%s\"> but contained <\"%s\">",
-                                     "Ok", "Bad");
+                                     "Expecting Result to be Ok containing <\"%s\"> but contained <\"%s\">. expected:<\"%s\"> but was:<\"%s\">",
+                                     expected, actual, expected, actual);
   }
 
   @Test
   public void itFailsWhenAssertingErrValueOnErrWithDifferentValue() throws Exception {
+    int expected = 1;
+    int actual = 0;
     assertThatAssertionErrorIsThrown(() -> assertThat(Result.err(0)).containsErr(1),
-                                     "Expecting Result to be Err containing <%s> but contained <%s>",
-                                     1, 0);
+                                     "Expecting Result to be Err containing <%s> but contained <%s>. expected:<%s> but was:<%s>",
+                                     expected, actual, expected, actual);
   }
 
   @Test


### PR DESCRIPTION
This PR enables the IntelliJ <Click to see difference> when comparing two Results. It doesn't change the comparison logic, but just the assertion message that is returned. 

By appending `expected:<%s> but was:<%s>` initelliJ recognizes there was an error comparing two different values and shows the very handy  `<Click to see difference>` button in the error message.

Before:
<img width="797" alt="Screenshot 2023-11-03 at 10 58 01 AM" src="https://github.com/HubSpot/algebra/assets/11463936/6018cb1a-c47e-4505-a2b2-c30e100d58cd">

After:
<img width="797" alt="Screenshot 2023-11-03 at 10 52 18 AM" src="https://github.com/HubSpot/algebra/assets/11463936/1423589f-3472-4097-9f1d-dfa61b84344e">
