### PR TITLE
Implement Result::all

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -29,14 +29,24 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return Results.err(NullValue.get());
   }
 
-  public static <SUCCESS_TYPE, ERROR_TYPE> Result<List<SUCCESS_TYPE>, ERROR_TYPE> all(Collection<Result<SUCCESS_TYPE, ERROR_TYPE>> results) {
-    return results.stream()
+  public static <SUCCESS_TYPE, ERROR_TYPE> Result<List<SUCCESS_TYPE>, ERROR_TYPE> all(
+    Collection<Result<SUCCESS_TYPE, ERROR_TYPE>> results
+  ) {
+    return results
+      .stream()
       .filter(Result::isErr)
       .findFirst()
-      .<Result<List<SUCCESS_TYPE>, ERROR_TYPE>>map(firstError -> Result.err(firstError.unwrapErrOrElseThrow()))
-      .orElseGet(() -> Result.ok(results.stream()
-        .map(Result::unwrapOrElseThrow)
-        .collect(ImmutableList.toImmutableList())));
+      .<Result<List<SUCCESS_TYPE>, ERROR_TYPE>>map(firstError ->
+        Result.err(firstError.unwrapErrOrElseThrow())
+      )
+      .orElseGet(() ->
+        Result.ok(
+          results
+            .stream()
+            .map(Result::unwrapOrElseThrow)
+            .collect(ImmutableList.toImmutableList())
+        )
+      );
   }
 
   Result() {}

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -32,7 +32,7 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
   /**
    * Performs a conversion operation that aggregates a collection of Results into a single Result.
    * <p>
-   * If any of the input Results are errors, the first encountered error is returned in a new Result of type Result<List<SUCCESS_TYPE>, ERROR_TYPE>.
+   * If any of the input Results are errors, the first encountered error is returned in a new Result of type Result&lt;List&lt;SUCCESS_TYPE&gt;, ERROR_TYPE&gt;.
    * If all input Results are successful, a new Result containing the list of unwrapped success values is returned.
    *
    * @param results A Collection of Result instances

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -29,6 +29,17 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return Results.err(NullValue.get());
   }
 
+  /**
+   * Performs a conversion operation that aggregates a collection of Results into a single Result.
+   * <p>
+   * If any of the input Results are errors, the first encountered error is returned in a new Result of type Result<List<SUCCESS_TYPE>, ERROR_TYPE>.
+   * If all input Results are successful, a new Result containing the list of unwrapped success values is returned.
+   *
+   * @param results A Collection of Result instances
+   * @param <SUCCESS_TYPE> The success type of the Results
+   * @param <ERROR_TYPE> The error type of the Results
+   * @return A Result containing either a list of success values or the first encountered error
+   */
   public static <SUCCESS_TYPE, ERROR_TYPE> Result<List<SUCCESS_TYPE>, ERROR_TYPE> all(
     Collection<Result<SUCCESS_TYPE, ERROR_TYPE>> results
   ) {

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -1,5 +1,8 @@
 package com.hubspot.algebra;
 
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -24,6 +27,16 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
 
   public static <SUCCESS_TYPE> Result<SUCCESS_TYPE, NullValue> nullErr() {
     return Results.err(NullValue.get());
+  }
+
+  public static <SUCCESS_TYPE, ERROR_TYPE> Result<List<SUCCESS_TYPE>, ERROR_TYPE> all(Collection<Result<SUCCESS_TYPE, ERROR_TYPE>> results) {
+    return results.stream()
+      .filter(Result::isErr)
+      .findFirst()
+      .<Result<List<SUCCESS_TYPE>, ERROR_TYPE>>map(firstError -> Result.err(firstError.unwrapErrOrElseThrow()))
+      .orElseGet(() -> Result.ok(results.stream()
+        .map(Result::unwrapOrElseThrow)
+        .collect(ImmutableList.toImmutableList())));
   }
 
   Result() {}

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -51,11 +51,13 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     if (!errors.isEmpty()) {
       return Result.err(errors);
     }
-    return Result.ok(results
-      .stream()
-      .filter(Result::isOk)
-      .map(Result::unwrapOrElseThrow)
-      .collect(ImmutableList.toImmutableList()));
+    return Result.ok(
+      results
+        .stream()
+        .filter(Result::isOk)
+        .map(Result::unwrapOrElseThrow)
+        .collect(ImmutableList.toImmutableList())
+    );
   }
 
   Result() {}

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -203,14 +203,22 @@ public class ResultTest {
 
   @Test
   public void itConvertsListOfResultsToResultOfList() {
-    List<Result<Integer, String>> xs = ImmutableList.of(Result.ok(1), Result.ok(2), Result.ok(3));
+    List<Result<Integer, String>> xs = ImmutableList.of(
+      Result.ok(1),
+      Result.ok(2),
+      Result.ok(3)
+    );
     Result<List<Integer>, String> rxs = Result.all(xs);
     assertThat(rxs.unwrapOrElseThrow()).containsExactly(1, 2, 3);
   }
 
   @Test
   public void itConvertsListOfResultsToFirstError() {
-    List<Result<Integer, String>> xs = ImmutableList.of(Result.ok(1), Result.ok(2), Result.err("error"));
+    List<Result<Integer, String>> xs = ImmutableList.of(
+      Result.ok(1),
+      Result.ok(2),
+      Result.err("error")
+    );
     Result<List<Integer>, String> rxs = Result.all(xs);
     assertThat(rxs.unwrapErrOrElseThrow()).isEqualTo("error");
   }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -200,4 +200,18 @@ public class ResultTest {
     assertThat(okResults).isEmpty();
     assertThat(errorResults).contains(ERR_RESULT.unwrapErrOrElseThrow());
   }
+
+  @Test
+  public void itConvertsListOfResultsToResultOfList() {
+    List<Result<Integer, String>> xs = ImmutableList.of(Result.ok(1), Result.ok(2), Result.ok(3));
+    Result<List<Integer>, String> rxs = Result.all(xs);
+    assertThat(rxs.unwrapOrElseThrow()).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  public void itConvertsListOfResultsToFirstError() {
+    List<Result<Integer, String>> xs = ImmutableList.of(Result.ok(1), Result.ok(2), Result.err("error"));
+    Result<List<Integer>, String> rxs = Result.all(xs);
+    assertThat(rxs.unwrapErrOrElseThrow()).isEqualTo("error");
+  }
 }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -220,6 +220,7 @@ public class ResultTest {
       Result.err("error2")
     );
     Result<List<Integer>, List<String>> actual = Result.all(results);
-    assertThat(actual.unwrapErrOrElseThrow()).containsExactlyInAnyOrder("error1", "error2");
+    assertThat(actual.unwrapErrOrElseThrow())
+      .containsExactlyInAnyOrder("error1", "error2");
   }
 }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -203,23 +203,23 @@ public class ResultTest {
 
   @Test
   public void itConvertsListOfResultsToResultOfList() {
-    List<Result<Integer, String>> xs = ImmutableList.of(
+    List<Result<Integer, String>> results = ImmutableList.of(
       Result.ok(1),
       Result.ok(2),
       Result.ok(3)
     );
-    Result<List<Integer>, String> rxs = Result.all(xs);
-    assertThat(rxs.unwrapOrElseThrow()).containsExactly(1, 2, 3);
+    Result<List<Integer>, String> actual = Result.all(results);
+    assertThat(actual.unwrapOrElseThrow()).containsExactly(1, 2, 3);
   }
 
   @Test
   public void itConvertsListOfResultsToFirstError() {
-    List<Result<Integer, String>> xs = ImmutableList.of(
+    List<Result<Integer, String>> results = ImmutableList.of(
       Result.ok(1),
       Result.ok(2),
       Result.err("error")
     );
-    Result<List<Integer>, String> rxs = Result.all(xs);
-    assertThat(rxs.unwrapErrOrElseThrow()).isEqualTo("error");
+    Result<List<Integer>, String> actual = Result.all(results);
+    assertThat(actual.unwrapErrOrElseThrow()).isEqualTo("error");
   }
 }

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -202,24 +202,24 @@ public class ResultTest {
   }
 
   @Test
-  public void itConvertsListOfResultsToResultOfList() {
+  public void itConvertsListOfOkResultsToOkResultOfList() {
     List<Result<Integer, String>> results = ImmutableList.of(
       Result.ok(1),
       Result.ok(2),
       Result.ok(3)
     );
-    Result<List<Integer>, String> actual = Result.all(results);
+    Result<List<Integer>, List<String>> actual = Result.all(results);
     assertThat(actual.unwrapOrElseThrow()).containsExactly(1, 2, 3);
   }
 
   @Test
-  public void itConvertsListOfResultsToFirstError() {
+  public void itConvertsListWithErrResultsToErrResultOfList() {
     List<Result<Integer, String>> results = ImmutableList.of(
       Result.ok(1),
-      Result.ok(2),
-      Result.err("error")
+      Result.err("error1"),
+      Result.err("error2")
     );
-    Result<List<Integer>, String> actual = Result.all(results);
-    assertThat(actual.unwrapErrOrElseThrow()).isEqualTo("error");
+    Result<List<Integer>, List<String>> actual = Result.all(results);
+    assertThat(actual.unwrapErrOrElseThrow()).containsExactlyInAnyOrder("error1", "error2");
   }
 }


### PR DESCRIPTION
It's common to end up with a list of results and then needing to either operate on all of the errors, or otherwise operate on all of the successes. This utility method simplifies getting at your lists of values by turning a `List<Result<Ok, Err>>` into a `Result<List<Ok>, List<Err>>`.

Before:

```java
List<Result<Success, Error>> results = tryFetchThings()
  .stream()
  .map(...)
  .collect(toList());

List<Error> errors = results
  .stream()
  .filter(Error::isError)
  .map(Result::unwrapErrOrElseThrow)
  .collect(toList());
if (!errors.isEmpty()) {
  logErrors(errors)
  return;
}

List<Success> oks = results
  .stream()
  .filter(Result::isOk)
  .map(Result::unwrapOrElseThrow)
  .collect(toList());
  
processOks(oks)
```

After:

```java
Result.all(
  tryFetchThings()
    .stream()
    .map(...)
    .collect(toList())
).consume(
  this::logErrors,
  this::processOks
);
```
  
<img width="752" alt="image" src="https://github.com/user-attachments/assets/a47f77d7-4f86-44d6-80b6-682c64ccd152" />