### PR TITLE
Add Result::coerceErr

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -132,6 +132,24 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return unwrapErrOrElseThrow(() -> new IllegalStateException(message));
   }
 
+  /**
+   * Coerces the success type of an error Result to any other type.
+   * This is a no-op for Ok results.
+   * <p />
+   * This method helps when you need to return an error result whose success type
+   * doesn't match the required return type.
+   *
+   * @param <NEW_SUCCESS_TYPE> The new success type parameter
+   * @return A Result with the same error value but a coerced success type
+   * @throws IllegalStateException if called on an Ok Result
+   */
+  public <NEW_SUCCESS_TYPE> Result<NEW_SUCCESS_TYPE, ERROR_TYPE> coerceErr() {
+    if (isOk()) {
+      throw new IllegalStateException("Cannot coerce an Ok result's success type");
+    }
+    return Result.err(unwrapErrOrElseThrow());
+  }
+
   public abstract <R> R match(Function<ERROR_TYPE, R> err, Function<SUCCESS_TYPE, R> ok);
 
   @Override

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -200,4 +200,19 @@ public class ResultTest {
     assertThat(okResults).isEmpty();
     assertThat(errorResults).contains(ERR_RESULT.unwrapErrOrElseThrow());
   }
+
+  @Test
+  public void itCoercesErr() {
+    Result<String, SampleError> errResult = Result.err(SampleError.TEST_ERROR);
+    Result<Integer, SampleError> coercedErrResult = errResult.coerceErr();
+
+    assertThat(coercedErrResult.isErr()).isTrue();
+    assertThat(coercedErrResult.unwrapErrOrElseThrow()).isEqualTo(SampleError.TEST_ERROR);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void itThrowsWhenCoerceErrCalledOnOk() {
+    Result<String, SampleError> okResult = Result.ok(SAMPLE_STRING);
+    okResult.coerceErr();
+  }
 }


### PR DESCRIPTION
This is my biggest pet peeve with Result! I regularly have to use this awful workaround when I want to return an err result with a `SUCCESS_TYPE` that doesn't match. Here's a real-world example that I obfuscated:
```java
  public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
    Result<Long, ExampleError> tryId = Optional
      .ofNullable(Longs.tryParse(urn.split()[1]))
      .map(Result::<Long, ExampleError>ok)
      .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID));
    if (tryId.isErr()) {
      // This works around Result<Long, ExampleError> not matching the 
      // method's return type Result<ExamplePrivilegeEgg, ExampleError>
      // even though we've confirmed it's an error and the error types match
      return tryId.mapOk(null);
    }
```

A _slightly_ more honest but even uglier alternative is this more common approach:
```java
  public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
    Result<Long, ExampleError> tryId = Optional
      .ofNullable(Longs.tryParse(urn.split()[1]))
      .map(Result::<Long, ExampleError>ok)
      .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID));
    if (tryId.isErr()) {
      // This works around Result<Long, ExampleError> not matching the 
      // method's return type Result<ExamplePrivilegeEgg, ExampleError>
      // even though we've confirmed it's an error and the error types match
      return Result.<ExamplePrivilegeEgg, ExampleError>err(tryId.unwrapErrOrElseThrow());
    }
```

With this new `Result::coerceErr` utility method, the example becomes:
```java
  public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
    Result<Long, ExampleError> tryId = Optional
      .ofNullable(Longs.tryParse(urn.split()[1]))
      .map(Result::<Long, ExampleError>ok)
      .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID));
    if (tryId.isErr()) {
      return tryId.coerceErr();
    }
```
<img width="626" alt="image" src="https://github.com/user-attachments/assets/2e9a8f46-bd81-41bf-9cb1-fd118918edc2" />