### PR TITLE
Add combinator

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/QuadFunction.java
+++ b/algebra/src/main/java/com/hubspot/algebra/QuadFunction.java
@@ -1,0 +1,6 @@
+package com.hubspot.algebra;
+
+@FunctionalInterface
+public interface QuadFunction<A, B, C, D, R> {
+  R apply(A a, B b, C c, D d);
+}

--- a/algebra/src/main/java/com/hubspot/algebra/QuintFunction.java
+++ b/algebra/src/main/java/com/hubspot/algebra/QuintFunction.java
@@ -1,0 +1,6 @@
+package com.hubspot.algebra;
+
+@FunctionalInterface
+public interface QuintFunction<A, B, C, D, E, R> {
+  R apply(A a, B b, C c, D d, E e);
+}

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -26,6 +26,20 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
     return Results.err(NullValue.get());
   }
 
+  /**
+   * Start combining multiple Results with type-safety.
+   * Each Result is accumulated while maintaining its type information,
+   * allowing direct access to all values in the combiner function.
+   *
+   * @param <A> Type of the first Result's value
+   * @param <E> Type of the error
+   * @param r1 First Result to combine
+   * @return A builder for further combination
+   */
+  public static <A, E> ResultCombinator.R1<A, E> combine(Result<A, E> r1) {
+    return ResultCombinator.combine(r1);
+  }
+
   Result() {}
 
   public boolean isOk() {

--- a/algebra/src/main/java/com/hubspot/algebra/ResultCombinator.java
+++ b/algebra/src/main/java/com/hubspot/algebra/ResultCombinator.java
@@ -23,7 +23,7 @@ class ResultCombinator {
   /**
    * Holder for one Result value.
    */
-  static class R1<A, E> {
+  public static class R1<A, E> {
 
     private final A value1;
     private final Result<?, E> error;
@@ -60,7 +60,7 @@ class ResultCombinator {
   /**
    * Holder for two Result values.
    */
-  static class R2<A, B, E> {
+  public static class R2<A, B, E> {
 
     private final A value1;
     private final B value2;
@@ -99,7 +99,7 @@ class ResultCombinator {
   /**
    * Holder for three Result values.
    */
-  static class R3<A, B, C, E> {
+  public static class R3<A, B, C, E> {
 
     private final A value1;
     private final B value2;
@@ -140,7 +140,7 @@ class ResultCombinator {
   /**
    * Holder for four Result values.
    */
-  static class R4<A, B, C, D, E> {
+  public static class R4<A, B, C, D, E> {
 
     private final A value1;
     private final B value2;
@@ -183,7 +183,7 @@ class ResultCombinator {
   /**
    * Holder for five Result values.
    */
-  static class R5<A, B, C, D, E, F> {
+  public static class R5<A, B, C, D, E, F> {
 
     private final A value1;
     private final B value2;

--- a/algebra/src/main/java/com/hubspot/algebra/ResultCombinator.java
+++ b/algebra/src/main/java/com/hubspot/algebra/ResultCombinator.java
@@ -1,0 +1,214 @@
+package com.hubspot.algebra;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A type-accumulating builder for combining Results.
+ * This approach builds up the type information through each step,
+ * allowing type-safe access to all accumulated values.
+ */
+class ResultCombinator {
+
+  /**
+   * Start combining with one Result.
+   */
+  public static <A, E> R1<A, E> combine(Result<A, E> r1) {
+    if (r1.isErr()) {
+      return new R1<>(null, r1.coerceErr());
+    }
+    return new R1<>(r1.unwrapOrElseThrow(), null);
+  }
+
+  /**
+   * Holder for one Result value.
+   */
+  static class R1<A, E> {
+
+    private final A value1;
+    private final Result<?, E> error;
+
+    private R1(A value1, Result<?, E> error) {
+      this.value1 = value1;
+      this.error = error;
+    }
+
+    /**
+     * Add a second Result to be combined.
+     */
+    public <B> R2<A, B, E> and(Result<B, E> r2) {
+      if (error != null) {
+        return new R2<>(value1, null, error);
+      }
+      if (r2.isErr()) {
+        return new R2<>(value1, null, r2.coerceErr());
+      }
+      return new R2<>(value1, r2.unwrapOrElseThrow(), null);
+    }
+
+    /**
+     * Complete the combination with a mapping function for one value.
+     */
+    public <R> Result<R, E> map(Function<A, R> mapper) {
+      if (error != null) {
+        return error.coerceErr();
+      }
+      return Result.ok(mapper.apply(value1));
+    }
+  }
+
+  /**
+   * Holder for two Result values.
+   */
+  static class R2<A, B, E> {
+
+    private final A value1;
+    private final B value2;
+    private final Result<?, E> error;
+
+    private R2(A value1, B value2, Result<?, E> error) {
+      this.value1 = value1;
+      this.value2 = value2;
+      this.error = error;
+    }
+
+    /**
+     * Add a third Result to be combined.
+     */
+    public <C> R3<A, B, C, E> and(Result<C, E> r3) {
+      if (error != null) {
+        return new R3<>(value1, value2, null, error);
+      }
+      if (r3.isErr()) {
+        return new R3<>(value1, value2, null, r3.coerceErr());
+      }
+      return new R3<>(value1, value2, r3.unwrapOrElseThrow(), null);
+    }
+
+    /**
+     * Complete the combination with a mapping function for two values.
+     */
+    public <R> Result<R, E> map(BiFunction<A, B, R> mapper) {
+      if (error != null) {
+        return error.coerceErr();
+      }
+      return Result.ok(mapper.apply(value1, value2));
+    }
+  }
+
+  /**
+   * Holder for three Result values.
+   */
+  static class R3<A, B, C, E> {
+
+    private final A value1;
+    private final B value2;
+    private final C value3;
+    private final Result<?, E> error;
+
+    private R3(A value1, B value2, C value3, Result<?, E> error) {
+      this.value1 = value1;
+      this.value2 = value2;
+      this.value3 = value3;
+      this.error = error;
+    }
+
+    /**
+     * Add a fourth Result to be combined.
+     */
+    public <D> R4<A, B, C, D, E> and(Result<D, E> r4) {
+      if (error != null) {
+        return new R4<>(value1, value2, value3, null, error);
+      }
+      if (r4.isErr()) {
+        return new R4<>(value1, value2, value3, null, r4.coerceErr());
+      }
+      return new R4<>(value1, value2, value3, r4.unwrapOrElseThrow(), null);
+    }
+
+    /**
+     * Complete the combination with a mapping function for three values.
+     */
+    public <R> Result<R, E> map(com.hubspot.algebra.TriFunction<A, B, C, R> mapper) {
+      if (error != null) {
+        return error.coerceErr();
+      }
+      return Result.ok(mapper.apply(value1, value2, value3));
+    }
+  }
+
+  /**
+   * Holder for four Result values.
+   */
+  static class R4<A, B, C, D, E> {
+
+    private final A value1;
+    private final B value2;
+    private final C value3;
+    private final D value4;
+    private final Result<?, E> error;
+
+    private R4(A value1, B value2, C value3, D value4, Result<?, E> error) {
+      this.value1 = value1;
+      this.value2 = value2;
+      this.value3 = value3;
+      this.value4 = value4;
+      this.error = error;
+    }
+
+    /**
+     * Add a fifth Result to be combined.
+     */
+    public <F> R5<A, B, C, D, F, E> and(Result<F, E> r5) {
+      if (error != null) {
+        return new R5<>(value1, value2, value3, value4, null, error);
+      }
+      if (r5.isErr()) {
+        return new R5<>(value1, value2, value3, value4, null, r5.coerceErr());
+      }
+      return new R5<>(value1, value2, value3, value4, r5.unwrapOrElseThrow(), null);
+    }
+
+    /**
+     * Complete the combination with a mapping function for four values.
+     */
+    public <R> Result<R, E> map(QuadFunction<A, B, C, D, R> mapper) {
+      if (error != null) {
+        return error.coerceErr();
+      }
+      return Result.ok(mapper.apply(value1, value2, value3, value4));
+    }
+  }
+
+  /**
+   * Holder for five Result values.
+   */
+  static class R5<A, B, C, D, E, F> {
+
+    private final A value1;
+    private final B value2;
+    private final C value3;
+    private final D value4;
+    private final E value5;
+    private final Result<?, F> error;
+
+    private R5(A value1, B value2, C value3, D value4, E value5, Result<?, F> error) {
+      this.value1 = value1;
+      this.value2 = value2;
+      this.value3 = value3;
+      this.value4 = value4;
+      this.value5 = value5;
+      this.error = error;
+    }
+
+    /**
+     * Complete the combination with a mapping function for five values.
+     */
+    public <R> Result<R, F> map(QuintFunction<A, B, C, D, E, R> mapper) {
+      if (error != null) {
+        return error.coerceErr();
+      }
+      return Result.ok(mapper.apply(value1, value2, value3, value4, value5));
+    }
+  }
+}

--- a/algebra/src/main/java/com/hubspot/algebra/TriFunction.java
+++ b/algebra/src/main/java/com/hubspot/algebra/TriFunction.java
@@ -1,0 +1,6 @@
+package com.hubspot.algebra;
+
+@FunctionalInterface
+public interface TriFunction<A, B, C, R> {
+  R apply(A a, B b, C c);
+}

--- a/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/ResultTest.java
@@ -215,4 +215,90 @@ public class ResultTest {
     Result<String, SampleError> okResult = Result.ok(SAMPLE_STRING);
     okResult.coerceErr();
   }
+
+  @Test
+  public void itCombinesTwoOkResults() {
+    Result<String, SampleError> result1 = Result.ok("Hello");
+    Result<Integer, SampleError> result2 = Result.ok(42);
+
+    Result<String, SampleError> combinedResult = Result
+      .combine(result1)
+      .and(result2)
+      .map((str, num) -> str + " " + num);
+
+    assertThat(combinedResult.isOk()).isTrue();
+    assertThat(combinedResult.unwrapOrElseThrow()).isEqualTo("Hello 42");
+  }
+
+  @Test
+  public void itCombinesOkAndErrResults() {
+    Result<String, SampleError> result1 = Result.ok("Hello");
+    Result<Integer, SampleError> result2 = Result.err(SampleError.TEST_ERROR);
+
+    Result<String, SampleError> combinedResult = Result
+      .combine(result1)
+      .and(result2)
+      .map((str, num) -> str + " " + num);
+
+    assertThat(combinedResult.isErr()).isTrue();
+    assertThat(combinedResult.unwrapErrOrElseThrow()).isEqualTo(SampleError.TEST_ERROR);
+  }
+
+  @Test
+  public void itCombinesTwoErrResults() {
+    Result<String, SampleError> result1 = Result.err(SampleError.TEST_ERROR);
+    Result<Integer, SampleError> result2 = Result.err(SampleError.TEST_ERROR_TWO);
+
+    Result<String, SampleError> combinedResult = Result
+      .combine(result1)
+      .and(result2)
+      .map((str, num) -> str + " " + num);
+
+    assertThat(combinedResult.isErr()).isTrue();
+    assertThat(combinedResult.unwrapErrOrElseThrow()).isEqualTo(SampleError.TEST_ERROR);
+  }
+
+  @Test
+  public void itCombinesFiveOkResults() {
+    Result<String, SampleError> result1 = Result.ok("Hello");
+    Result<Integer, SampleError> result2 = Result.ok(42);
+    Result<Double, SampleError> result3 = Result.ok(3.14);
+    Result<Boolean, SampleError> result4 = Result.ok(true);
+    Result<Character, SampleError> result5 = Result.ok('A');
+
+    Result<String, SampleError> combinedResult = Result
+      .combine(result1)
+      .and(result2)
+      .and(result3)
+      .and(result4)
+      .and(result5)
+      .map((str, num, dbl, bool, chr) ->
+        str + " " + num + " " + dbl + " " + bool + " " + chr
+      );
+
+    assertThat(combinedResult.isOk()).isTrue();
+    assertThat(combinedResult.unwrapOrElseThrow()).isEqualTo("Hello 42 3.14 true A");
+  }
+
+  @Test
+  public void itCombinesFiveResultsWithAnErr() {
+    Result<String, SampleError> result1 = Result.ok("Hello");
+    Result<Integer, SampleError> result2 = Result.err(SampleError.TEST_ERROR);
+    Result<Double, SampleError> result3 = Result.ok(3.14);
+    Result<Boolean, SampleError> result4 = Result.ok(true);
+    Result<Character, SampleError> result5 = Result.ok('A');
+
+    Result<String, SampleError> combinedResult = Result
+      .combine(result1)
+      .and(result2)
+      .and(result3)
+      .and(result4)
+      .and(result5)
+      .map((str, num, dbl, bool, chr) ->
+        str + " " + num + " " + dbl + " " + bool + " " + chr
+      );
+
+    assertThat(combinedResult.isErr()).isTrue();
+    assertThat(combinedResult.unwrapErrOrElseThrow()).isEqualTo(SampleError.TEST_ERROR);
+  }
 }


### PR DESCRIPTION
It's common when validating multiple inputs (something like form validation) to have many possible `results` where you can only continue if they're all `ok` and you need to effectively short-circuit on any `err`.

Using `Result::mapOk` and `Result::flatMapOk` can be handy, but when you need to refer to the unwrapped `ok` values all within one scope, you end up with the "pyramid of doom" nested indentation:
```java
public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
  String[] split = urn.split(":");
  if (split.length != 3) {
    return Result.err(ExampleError.INVALID_URN);
  }

  return Optional
    .ofNullable(Longs.tryParse(split[1]))
    .map(Result::<Long, ExampleError>ok)
    .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID))
    .flatMapOk(id ->
      EntityType
        .from(split[0])
        .flatMapOk(privilegeType ->
          GrantType
            .from(split[2])
            .flatMapOk(grantType ->
              Result.ok(
                // Here we need id, privilegeType, and grantType from the scopes above
                ExamplePrivilegeEgg
                  .builder()
                  .setEntityId(id)
                  .setEntityType(privilegeType)
                  .setGrantType(grantType)
                  .build()
              )
            )
        )
    );
}
```
An alternative approach is to check each intermediate `result` and return early with guard clauses which is much more readable but we end up having a pile of extra code blocks, `isErr` checks, and then having to `unwrapOrElseThrow()` a bunch of times at the end:
```java
public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
  String[] split = urn.split(":");
  if (split.length != 3) {
    return Result.err(ExampleError.INVALID_URN);
  }

  Result<EntityType, ExampleError> entityResult = EntityType.from(split[0]);
  if (entityResult.isErr()) {
    return entityResult.coerceErr();
  }

  Result<GrantType, ExampleError> grantResult = GrantType.from(split[2]);
  if (grantResult.isErr()) {
    return grantResult.coerceErr();
  }

  Result<Long, ExampleError> idResult = Optional
    .ofNullable(Longs.tryParse(split[1]))
    .map(Result::<Long, ExampleError>ok)
    .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID));
  if (idResult.isErr()) {
    return idResult.coerceErr();
  }

  // unwrap, unwrap, unwrap, etc.
  return ExamplePrivilegeEgg.builder()
      .setEntityId(idResult.unwrapOrElseThrow())
      .setEntityType(entityResult.unwrapOrElseThrow())
      .setGrantType(grantResult.unwrapOrElseThrow())
      .build());
}
```
This PR adds a `Result::combine` utility method that let's you combine up to 5 separate `results`, operate on them all within a single mapping function, and return a new `result`, short-circuiting if any of the input `results` contained errors.
```java
public static Result<ExamplePrivilegeEgg, ExampleError> fromUrn(String urn) {
  String[] split = urn.split(":");
  if (split.length != 3) {
    return Result.err(ExampleError.INVALID_URN);
  }

  Result<EntityType, ExampleError> entityResult = EntityType.from(split[0]);
  Result<GrantType, ExampleError> grantResult = GrantType.from(split[2]);
  Result<Long, ExampleError> idResult = Optional
    .ofNullable(Longs.tryParse(split[1]))
    .map(Result::<Long, ExampleError>ok)
    .orElseGet(() -> Result.err(ExampleError.INVALID_PRIVILEGE_ID));

  // Clean, flat chain with safely typed, named parameters
  return Result.combine(idResult)
    .and(entityResult)
    .and(grantResult)
    .map((id, entityType, grantType) -> ExamplePrivilegeEgg
      .builder()
      .setEntityId(id)
      .setEntityType(entityType)
      .setGrantType(grantType)
      .build());
}
```
<img width="474" alt="image" src="https://github.com/user-attachments/assets/86288188-da49-4725-b382-02855d2704a0" />
