### PR TITLE
Use `Throwable` as the exception cause in `unwrapOrElseThrow`

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -131,7 +131,13 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
   }
 
   public ERROR_TYPE unwrapErrOrElseThrow() {
-    return unwrapErrOrElseThrow(ok -> new IllegalStateException(ok.toString()));
+    return unwrapErrOrElseThrow(ok -> {
+      if (ok instanceof Throwable) {
+        return new IllegalStateException((Throwable) ok);
+      } else {
+        return new IllegalStateException(ok.toString());
+      }
+    });
   }
 
   public ERROR_TYPE expectErr(String message) {

--- a/algebra/src/main/java/com/hubspot/algebra/Result.java
+++ b/algebra/src/main/java/com/hubspot/algebra/Result.java
@@ -105,7 +105,13 @@ public abstract class Result<SUCCESS_TYPE, ERROR_TYPE> {
   }
 
   public SUCCESS_TYPE unwrapOrElseThrow() {
-    return unwrapOrElseThrow(err -> new IllegalStateException(err.toString()));
+    return unwrapOrElseThrow(err -> {
+      if (err instanceof Throwable) {
+        return new IllegalStateException((Throwable) err);
+      } else {
+        return new IllegalStateException(err.toString());
+      }
+    });
   }
 
   public SUCCESS_TYPE expect(String message) {


### PR DESCRIPTION
Currently the structured call stack and other exception class-specific information is lost because the error is converted to a string unconditionally.

This PR changes the behavior to check if the error is `Throwable`, and if so, it uses it as the cause of the `IllegalStateException`.

It also does the same thing for `unwrapErrOrElseThrow` for consistency and completeness, though I imagine this will be pretty rare.

## Out of Scope

It might be nice to throw the actual error and not wrap it in `IllegalStateException`. Not sure how this could be accomplished with Java generics, though. At least with this PR the actual error can still be accessed by traversing the cause chain.