### PR TITLE
fix(build): expose module licenses in generated license reports

### DIFF
--- a/algebra-jackson/pom.xml
+++ b/algebra-jackson/pom.xml
@@ -59,4 +59,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/algebra-testing/pom.xml
+++ b/algebra-testing/pom.xml
@@ -28,4 +28,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/algebra/pom.xml
+++ b/algebra/pom.xml
@@ -55,4 +55,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>


### PR DESCRIPTION
# Description of Changes

Added Apache License 2.0 metadata to the Maven POM files for:

- `algebra-jackson`
- `algebra-testing`
- `algebra`

This change ensures that the modules' license is detected and displayed.

Previously, no license information was shown for these modules because their POM files did not explicitly declare a license.

## Why the license metadata was not detected

`com.github.jk1.dependency-license-report` derives license information from the Maven metadata of each resolved dependency rather than from the repository's `LICENSE` file.

The affected module POMs did not contain their own `<licenses>` section. The Apache 2.0 license was declared only in the parent project POM. Although the plugin supports collecting licenses from parent POMs, this depends on the complete parent POM chain being resolved and interpreted correctly. For these artifacts, that inherited license did not result in usable module-level license metadata, so the modules appeared without a license in `checkLicense` and `generateLicenseReport`.

Declaring the Apache 2.0 license directly in every published module POM makes each artifact's metadata self-contained. This allows the plugin to detect the license reliably without depending on parent POM traversal.